### PR TITLE
SIGINFO produces exception when running on EC2 and linux (gentoo) and ruby 1.8.7 p 302

### DIFF
--- a/lib/rubygems/mirror/command.rb
+++ b/lib/rubygems/mirror/command.rb
@@ -54,7 +54,7 @@ Multiple sources and destinations may be specified.
       progress = ui.progress_reporter num_to_fetch,
                                   "Fetching #{num_to_fetch} gems"
 
-      trap(:INFO) { puts "Fetched: #{progress.count}/#{num_to_fetch}" }
+      # trap(:INFO) { puts "Fetched: #{progress.count}/#{num_to_fetch}" }
 
       mirror.update_gems { progress.updated true }
 
@@ -63,7 +63,7 @@ Multiple sources and destinations may be specified.
       progress = ui.progress_reporter num_to_delete,
                                  "Deleting #{num_to_delete} gems"
 
-      trap(:INFO) { puts "Fetched: #{progress.count}/#{num_to_delete}" }
+      # trap(:INFO) { puts "Fetched: #{progress.count}/#{num_to_delete}" }
 
       mirror.delete_gems { progress.updated true }
     end


### PR DESCRIPTION
I've commented out the lines there, maybe should use SIGUSR1 or SIGUSR2 instead.

rake aborted!
unsupported signal SIGINFO
./lib/rubygems/mirror/command.rb:57:in `trap'
./lib/rubygems/mirror/command.rb:57:in`execute'
./lib/rubygems/mirror/command.rb:35:in `each'
./lib/rubygems/mirror/command.rb:35:in`execute'
