### PR TITLE
Remove rubyforge_name from Rakefile.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,6 @@ Hoe.spec 'rubygems-mirror' do
   self.extra_rdoc_files = FileList["**/*.rdoc"]
   self.history_file     = "CHANGELOG.rdoc"
   self.readme_file      = "README.rdoc"
-  self.rubyforge_name   = 'rubygems'
   self.testlib          = :minitest
 end
 


### PR DESCRIPTION
Hi, when I try to run rake -T I get this error:

rake aborted!
NoMethodError: undefined method `rubyforge_name=' for #<Hoe:0x007f7d9424bf30>
/home/gramos/srcs/rubygems-mirror/Rakefile:18:in`block in <top (required)>'
/home/gramos/srcs/rubygems-mirror/Rakefile:6:in `<top (required)>'
(See full trace by running task with --trace)

This change fix that problem.
