### PR TITLE
Remove gem deps warnings on build.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,12 @@ Hoe.spec 'rubygems-mirror' do
   developer('James Tucker', 'jftucker@gmail.com')
   license "MIT"
 
-  extra_dev_deps << %w[hoe-doofus >=1.0.0]
-  extra_dev_deps << %w[hoe-git >=1.3.0]
-  extra_dev_deps << %w[hoe-gemcutter >=1.0.0]
-  extra_dev_deps << %w[builder >=2.1.2]
-  extra_dev_deps << %w[minitest >=5.4.0]
-  extra_deps     << %w[net-http-persistent >=2.1]
+  extra_dev_deps << %w[hoe-doofus ~>1.0]
+  extra_dev_deps << %w[hoe-git ~>1.3]
+  extra_dev_deps << %w[hoe-gemcutter ~>1.0]
+  extra_dev_deps << %w[builder ~>2.1]
+  extra_dev_deps << %w[minitest ~>5.4]
+  extra_deps     << %w[net-http-persistent ~>2.1]
 
   self.extra_rdoc_files = FileList["**/*.rdoc"]
   self.history_file     = "CHANGELOG.rdoc"


### PR DESCRIPTION
This pull request remove these warnins on build the gem:

gramos: ~/srcs/rubygems-mirror 2.2.0dev((detached from 9023c70))$ rake gem
mkdir -p pkg
mkdir -p pkg
mkdir -p pkg/rubygems-mirror-1.0.1
rm -f pkg/rubygems-mirror-1.0.1/.autotest
ln .autotest pkg/rubygems-mirror-1.0.1/.autotest
rm -f pkg/rubygems-mirror-1.0.1/CHANGELOG.rdoc
ln CHANGELOG.rdoc pkg/rubygems-mirror-1.0.1/CHANGELOG.rdoc
rm -f pkg/rubygems-mirror-1.0.1/Manifest.txt
ln Manifest.txt pkg/rubygems-mirror-1.0.1/Manifest.txt
rm -f pkg/rubygems-mirror-1.0.1/README.rdoc
ln README.rdoc pkg/rubygems-mirror-1.0.1/README.rdoc
rm -f pkg/rubygems-mirror-1.0.1/Rakefile
ln Rakefile pkg/rubygems-mirror-1.0.1/Rakefile
mkdir -p pkg/rubygems-mirror-1.0.1/lib/rubygems
rm -f pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror.rb
ln lib/rubygems/mirror.rb pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror.rb
mkdir -p pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror
rm -f pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/command.rb
ln lib/rubygems/mirror/command.rb pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/command.rb
rm -f pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/fetcher.rb
ln lib/rubygems/mirror/fetcher.rb pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/fetcher.rb
rm -f pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/pool.rb
ln lib/rubygems/mirror/pool.rb pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/pool.rb
rm -f pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/test_setup.rb
ln lib/rubygems/mirror/test_setup.rb pkg/rubygems-mirror-1.0.1/lib/rubygems/mirror/test_setup.rb
rm -f pkg/rubygems-mirror-1.0.1/lib/rubygems_plugin.rb
ln lib/rubygems_plugin.rb pkg/rubygems-mirror-1.0.1/lib/rubygems_plugin.rb
mkdir -p pkg/rubygems-mirror-1.0.1/test
rm -f pkg/rubygems-mirror-1.0.1/test/test_gem_mirror.rb
ln test/test_gem_mirror.rb pkg/rubygems-mirror-1.0.1/test/test_gem_mirror.rb
touch pkg/rubygems-mirror-1.0.1/.gemtest
cd pkg/rubygems-mirror-1.0.1
WARNING:  open-ended dependency on net-http-persistent (>= 2.1) is not recommended
  if net-http-persistent is semantically versioned, use:
    add_runtime_dependency 'net-http-persistent', '~> 2.1'
WARNING:  open-ended dependency on hoe-doofus (>= 1.0.0, development) is not recommended
  if hoe-doofus is semantically versioned, use:
    add_development_dependency 'hoe-doofus', '~> 1.0', '>= 1.0.0'
WARNING:  open-ended dependency on hoe-git (>= 1.3.0, development) is not recommended
  if hoe-git is semantically versioned, use:
    add_development_dependency 'hoe-git', '~> 1.3', '>= 1.3.0'
WARNING:  open-ended dependency on hoe-gemcutter (>= 1.0.0, development) is not recommended
  if hoe-gemcutter is semantically versioned, use:
    add_development_dependency 'hoe-gemcutter', '~> 1.0', '>= 1.0.0'
WARNING:  open-ended dependency on builder (>= 2.1.2, development) is not recommended
  if builder is semantically versioned, use:
    add_development_dependency 'builder', '~> 2.1', '>= 2.1.2'
WARNING:  open-ended dependency on minitest (>= 5.4.0, development) is not recommended
  if minitest is semantically versioned, use:
    add_development_dependency 'minitest', '~> 5.4', '>= 5.4.0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rubygems-mirror
  Version: 1.0.1
  File: rubygems-mirror-1.0.1.gem
