### PR TITLE
Fix avoid attempting to rebuild the index.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,12 @@ Hoe.spec 'rubygems-mirror' do
   developer('James Tucker', 'jftucker@gmail.com')
   license "MIT"
 
-  extra_dev_deps << %w[hoe-doofus >=1.0.0]
-  extra_dev_deps << %w[hoe-git >=1.3.0]
-  extra_dev_deps << %w[hoe-gemcutter >=1.0.0]
-  extra_dev_deps << %w[builder >=2.1.2]
-  extra_dev_deps << %w[minitest >=5.4.0]
-  extra_deps     << %w[net-http-persistent >=2.1]
+  extra_dev_deps << %w[hoe-doofus ~>1.0]
+  extra_dev_deps << %w[hoe-git ~>1.3]
+  extra_dev_deps << %w[hoe-gemcutter ~>1.0]
+  extra_dev_deps << %w[builder ~>2.1]
+  extra_dev_deps << %w[minitest ~>5.4]
+  extra_deps     << %w[net-http-persistent ~>2.1]
 
   self.extra_rdoc_files = FileList["**/*.rdoc"]
   self.history_file     = "CHANGELOG.rdoc"

--- a/lib/rubygems/mirror/command.rb
+++ b/lib/rubygems/mirror/command.rb
@@ -19,6 +19,9 @@ document that looks like this:
   - from: http://gems.example.com # source repository URI
     to: /path/to/mirror           # destination directory
     parallelism: 10               # use 10 threads for downloads
+    retries: 3                    # retry 3 times if fail to download a gem, optional, def is 1. (no retry)
+    delete: false                 # whether delete gems (if remote ones are removed),optional, default is false. 
+    skiperror: true               # whether skip error, optional, def is true. will stop at error if set this to false.
 
 Multiple sources and destinations may be specified.
     EOF
@@ -41,10 +44,14 @@ Multiple sources and destinations may be specified.
       save_to = File.expand_path mir['to']
       parallelism = mir['parallelism']
 
+      retries = mir['retries'] || 1
+      skiperror = mir['skiperror']
+      delete = mir['delete']
+
       raise "Directory not found: #{save_to}" unless File.exist? save_to
       raise "Not a directory: #{save_to}" unless File.directory? save_to
 
-      mirror = Gem::Mirror.new(get_from, save_to, parallelism)
+      mirror = Gem::Mirror.new(get_from, save_to, parallelism, retries, skiperror)
       
       say "Fetching: #{mirror.from(Gem::Mirror::SPECS_FILE_Z)} with #{parallelism} threads"
       mirror.update_specs
@@ -60,14 +67,13 @@ Multiple sources and destinations may be specified.
 
       mirror.update_gems { progress.updated true }
 
-      num_to_delete = mirror.gems_to_delete.size
-
-      progress = ui.progress_reporter num_to_delete,
-                                 "Deleting #{num_to_delete} gems"
-
-      trap(:INFO) { puts "Fetched: #{progress.count}/#{num_to_delete}" } if SUPPORTS_INFO_SIGNAL
-
-      mirror.delete_gems { progress.updated true }
+      if delete
+        num_to_delete = mirror.gems_to_delete.size
+        progress = ui.progress_reporter num_to_delete,
+                                  "Deleting #{num_to_delete} gems"
+        trap(:INFO) { puts "Fetched: #{progress.count}/#{num_to_delete}" } if SUPPORTS_INFO_SIGNAL
+        mirror.delete_gems { progress.updated true }
+      end  
     end
   end
 end

--- a/lib/rubygems/mirror/fetcher.rb
+++ b/lib/rubygems/mirror/fetcher.rb
@@ -5,8 +5,13 @@ class Gem::Mirror::Fetcher
   # TODO  beef
   class Error < StandardError; end
 
-  def initialize
+  def initialize opts = {}
     @http = Net::HTTP::Persistent.new(self.class.name, :ENV)
+    @opts = opts
+
+    # default opts
+    @opts[:retries] ||= 1
+    @opts[:skiperror] = true if @opts[:skiperror].nil?
   end
 
   # Fetch a source path under the base uri, and put it in the same or given
@@ -17,9 +22,17 @@ class Gem::Mirror::Fetcher
     req = Net::HTTP::Get.new URI.parse(uri).path
     req.add_field 'If-Modified-Since', modified_time if modified_time
 
-    @http.request URI(uri), req do |resp|
-      return handle_response(resp, path)
-    end
+    retries = @opts[:retries]
+    begin
+      puts "get: #{uri}, #{retries}"
+      @http.request URI(uri), req do |resp|
+        return handle_response(resp, path)
+      end
+    rescue Error
+      retries -= 1
+      retry if retries > 0
+      raise if not @opts[:skiperror]
+    end 
   end
 
   # Handle an http response, follow redirects, etc. returns true if a file was
@@ -32,7 +45,7 @@ class Gem::Mirror::Fetcher
     when 200
       write_file(resp, path)
     when 403, 404
-      warn "#{resp.code} on #{File.basename(path)}"
+      raise Error,"#{resp.code} on #{File.basename(path)}"
     else
       raise Error, "unexpected response #{resp.inspect}"
     end

--- a/lib/rubygems/mirror/test_setup.rb
+++ b/lib/rubygems/mirror/test_setup.rb
@@ -68,10 +68,13 @@ class Gem::Mirror
 
       @source_working = working = Dir.mktmpdir("test_gem_source_#{$$}")
 
+      FileUtils.mkdir_p rzspecdir = File.join(@source_path, "quick/Marshal.#{Gem.marshal_version}")
+
       Dir.mkdir File.join(working, 'lib')
 
       gemspecs = %w[a b c].map do |name|
         FileUtils.touch File.join(working, 'lib', "#{name}.rb")
+        FileUtils.touch File.join(rzspecdir, "#{name}spec.rz")
         Gem::Specification.new do |s|
           s.platform = Gem::Platform::RUBY
           s.name = name

--- a/test/test_gem_mirror.rb
+++ b/test/test_gem_mirror.rb
@@ -32,9 +32,14 @@ class TestGemMirror < Minitest::Test
         Dir[path + '/gems/*'].map { |f| File.basename(f) }
       end
 
+      source_rz_specs, mirror_rz_specs = [source_path, mirror_path].map do |path|
+        Dir[path + "/quick/Marshal.#{Gem.marshal_version}/*"].map { |f| File.basename(f) }
+      end
+
       assert_equal source_gems, mirror_gems
+      assert_equal source_rz_specs, mirror_rz_specs
       # XXX(raggi): need to figure out how to hide the system gems in 2.0
-      assert 3 <= updates
+      assert 6 <= updates
     end
   end
 


### PR DESCRIPTION
- Fix avoid attempting to rebuild the index.

To get a local mirror working, I had problems with missing gemspec.rz files under the quick/Marshal directory. The original assumed that a gemspec file was downloaded along with the original gem, but I'd managed to lose some earlier gemspec files and didn't want to redownload the entire collection.  
