### PR TITLE
Mirror prerelease gems

### DIFF
--- a/lib/rubygems/mirror/command.rb
+++ b/lib/rubygems/mirror/command.rb
@@ -46,7 +46,10 @@ Multiple sources and destinations may be specified.
 
       mirror = Gem::Mirror.new(get_from, save_to, parallelism)
       
-      say "Fetching: #{mirror.from(Gem::Mirror::SPECS_FILE_Z)} with #{parallelism} threads"
+      Gem::Mirror::SPECS_FILES.each do |sf|
+        say "Fetching: #{mirror.from(sf)}"
+      end
+
       mirror.update_specs
 
       say "Total gems: #{mirror.gems.size}"

--- a/lib/rubygems/mirror/test_setup.rb
+++ b/lib/rubygems/mirror/test_setup.rb
@@ -90,6 +90,28 @@ class Gem::Mirror
         end
       end
 
+      # add prerelease gem versions
+      prerelease_gemspecs = %w[x y].map do |name|
+        FileUtils.touch File.join(working, 'lib', "#{name}.rb")
+        FileUtils.touch File.join(rzspecdir, "#{name}spec.rz")
+        Gem::Specification.new do |s|
+          s.platform = Gem::Platform::RUBY
+          s.name = name
+          s.version = "0.1.b"
+          s.author = 'rubygems'
+          s.email = 'example@example.com'
+          s.homepage = 'http://example.com'
+          s.has_rdoc = false
+          s.description = 'desc'
+          s.summary = "summ"
+          s.require_paths = %w[lib]
+          s.files = %W[lib/#{name}.rb]
+          s.rubyforge_project = 'rubygems'
+        end
+      end
+
+      gemspecs.concat(prerelease_gemspecs)
+
       gemspecs.each do |spec|
         path = File.join(working, "#{spec.name}.gemspec")
         open(path, 'w') do |io|

--- a/test/test_gem_mirror.rb
+++ b/test/test_gem_mirror.rb
@@ -16,8 +16,9 @@ class TestGemMirror < Minitest::Test
     with_server do
       mirror = Gem::Mirror.new(*opts)
       mirror.update_specs
-      assert File.exist?(mirror_path + "/#{Gem::Mirror::SPECS_FILE_Z}")
-      assert File.exist?(mirror_path + "/#{Gem::Mirror::SPECS_FILE_Z}")
+      Gem::Mirror::SPECS_FILES.each do |sf|
+        assert File.exist?(mirror_path + "/#{sf}.gz")
+      end
     end
   end
 
@@ -39,7 +40,7 @@ class TestGemMirror < Minitest::Test
       assert_equal source_gems, mirror_gems
       assert_equal source_rz_specs, mirror_rz_specs
       # XXX(raggi): need to figure out how to hide the system gems in 2.0
-      assert 6 <= updates
+      assert 10 <= updates
     end
   end
 


### PR DESCRIPTION
Addresses https://github.com/rubygems/rubygems-mirror/issues/6. Commit is largely based on https://github.com/mdkent/rubygems-mirror/commit/57a016e.
