### PR TITLE
Speedup gunzipping

### DIFF
--- a/lib/rubygems/mirror.rb
+++ b/lib/rubygems/mirror.rb
@@ -28,13 +28,25 @@ class Gem::Mirror
     File.join(@to, *args)
   end
 
+  if RbConfig::CONFIG['SHELL'] == '/bin/bash' && system('which zcat >/dev/null')
+    def gunzip(src, dest)
+      open(dest, 'wb') do |f|
+        system("zcat", src, out: f)
+      end
+    end
+  else
+    def gunzip(src, dest)
+      open(dest, 'wb') { |f| f << Gem.gunzip(File.read(src)) }
+    end
+  end
+
   def update_specs
     SPECS_FILES.each do |sf|
       sfz = "#{sf}.gz"
 
       specz = to(sfz)
       @fetcher.fetch(from(sfz), specz)
-      open(to(sf), 'wb') { |f| f << Gem.gunzip(File.read(specz)) }
+      gunzip(specz, to(sf))
     end
   end
 

--- a/lib/rubygems/mirror.rb
+++ b/lib/rubygems/mirror.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'fileutils'
+require 'zlib'
 
 class Gem::Mirror
   autoload :Fetcher, 'rubygems/mirror/fetcher'
@@ -28,16 +29,8 @@ class Gem::Mirror
     File.join(@to, *args)
   end
 
-  if RbConfig::CONFIG['SHELL'] == '/bin/bash' && system('which zcat >/dev/null')
-    def gunzip(src, dest)
-      open(dest, 'wb') do |f|
-        system("zcat", src, out: f)
-      end
-    end
-  else
-    def gunzip(src, dest)
-      open(dest, 'wb') { |f| f << Gem.gunzip(File.read(src)) }
-    end
+  def gunzip(src, dest)
+    open(dest, 'wb') { |f| f << Zlib::GzipReader.open(src).read }
   end
 
   def update_specs


### PR DESCRIPTION
Gunzipping the specs.4.8.gz file on my PC takes about 16 seconds with `Gem.gunzip`.
It's virtually instantaneous (80ms) with zcat/gunzip (i.e., it it 200
times faster).

This patch uses zcat instead of Gem.gunzip, if it is available. (The
availability check could probably be done better, but I don't know how
to do it properly.)

Just a suggestion.