### PR TITLE
Forcibly load OpenSSL to handle autoloading issues in net/http/persis…

### DIFF
--- a/lib/rubygems/mirror/fetcher.rb
+++ b/lib/rubygems/mirror/fetcher.rb
@@ -1,3 +1,11 @@
+# We forcibly require OpenSSL, because net/http/persistent will only autoload
+# it. On some Rubies, autoload fails but explicit require succeeds.
+begin
+  require 'openssl'
+rescue LoadError
+  # some Ruby builds don't have OpenSSL
+end
+
 require 'net/http/persistent'
 require 'time'
 


### PR DESCRIPTION
Forcibly require OpenSSL, because net/http/persistent will only autoload it. On some Rubies, autoload fails but explicit require succeeds.  This is to resolve #36 
