### PR TITLE
Remove `puts` URI logging from Gem::Mirror::Fetcher

### DIFF
--- a/lib/rubygems/mirror/fetcher.rb
+++ b/lib/rubygems/mirror/fetcher.rb
@@ -23,10 +23,8 @@ class Gem::Mirror::Fetcher
     req.add_field 'If-Modified-Since', modified_time if modified_time
 
     retries = @opts[:retries]
-    
+
     begin
-      puts "get: #{uri}, #{retries}"
-      
       # Net::HTTP will throw an exception on things like http timeouts.
       # Therefore some generic error handling is needed in case no response
       # is returned so the whole mirror operation doesn't abort prematurely.


### PR DESCRIPTION
This line was introduced in 297bfff53f2b4577a8f24b7500b515fca202bd34. It makes the output of `gem mirror` a lot more verbose than that of v1.0.1.