### PR TITLE
Add hashdir support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,9 +34,31 @@ will maintain stability in master.
       retries: 3
       delete: false 
       skiperror: true
+      hashdir: false
 
 * Either install the gem, then run `gem mirror`, or
 * Clone then run `rake mirror:update`
+
+=== Apache configuration for hashdir
+
+When rubygem-mirror is configured with hashdir: true, additional configuration
+for your web server will be required. Below are the Apache2 RewriteRules you may
+need:
+
+    RewriteEngine On
+
+    # Rubygem's URL's are:
+    # /gem/gems/foobar-1.0.0.gem
+    RewriteCond %{REQUEST_URI} ^/gem/gems/([^/])([^/])([^/]*)
+    RewriteCond %{DOCUMENT_ROOT}/gem/gems/$1/$1$2/ -d
+    RewriteRule ^/gem/gems/([^/])([^/])([^/]*)?$ /gem/gems/$1/$1$2/$1$2$3 [L]
+
+    # Rubygem's URL's are:
+    # /gem/quick/Marshal.4.8/foobar-1.0.0.gemspec.rz
+    RewriteCond %{REQUEST_URI} ^/gem/quick/([^/]+)/([^/])([^/])([^/]*)
+    RewriteCond %{DOCUMENT_ROOT}/gem/quick/$1/$2/$2$3/ -d
+    RewriteRule ^/gem/quick/([^/]+)/([^/])([^/])([^/]*)?$ /gem/quick/$1/$2/$2$3/$2$3$4 [L]
+
 
 == INSTALL:
 

--- a/lib/rubygems/mirror/command.rb
+++ b/lib/rubygems/mirror/command.rb
@@ -22,6 +22,8 @@ document that looks like this:
     retries: 3                    # retry 3 times if fail to download a gem, optional, def is 1. (no retry)
     delete: false                 # whether delete gems (if remote ones are removed),optional, default is false. 
     skiperror: true               # whether skip error, optional, def is true. will stop at error if set this to false.
+    hashdir: false                # store files by directory hashes, meaning that they can reside on a filesystem
+                                  # with directory size limits. Default is false.
 
 Multiple sources and destinations may be specified.
     EOF
@@ -45,12 +47,13 @@ Multiple sources and destinations may be specified.
       parallelism = mir['parallelism']
       retries = mir['retries'] || 1
       skiperror = mir['skiperror']
+      hashdir = mir['hashdir'] || false
       delete = mir['delete']
 
       raise "Directory not found: #{save_to}" unless File.exist? save_to
       raise "Not a directory: #{save_to}" unless File.directory? save_to
 
-      mirror = Gem::Mirror.new(get_from, save_to, parallelism, retries, skiperror)
+      mirror = Gem::Mirror.new(get_from, save_to, parallelism, retries, skiperror, hashdir)
       
       Gem::Mirror::SPECS_FILES.each do |sf|
         say "Fetching: #{mirror.from(sf)}"


### PR DESCRIPTION
To support older filesystems (EG: AFS), we need to add support for
directory hashes, to deal with directory size limits.

Disabled by default to maintain backwards compatibility, when enabled
filenames are hashed by filename, and directories created. EG:

  gems/foobar.gem becomes gems/f/fo/foobar.gem

Signed-off-by: Paul Belanger <pabelanger@redhat.com>