### PR TITLE
Check existence of gems whose name starts with dot

### DIFF
--- a/lib/rubygems/mirror.rb
+++ b/lib/rubygems/mirror.rb
@@ -55,7 +55,7 @@ class Gem::Mirror
   end
 
   def existing_gems
-    Dir[to('gems', '*.gem')].entries.map { |f| File.basename(f) }
+    Dir.glob(to('gems', '*.gem'), File::FNM_DOTMATCH).entries.map { |f| File.basename(f) }
   end
 
   def existing_gemspecs


### PR DESCRIPTION
There is a gem named [`.cat`](https://rubygems.org/gems/.cat).
`existing_gems` method misses a file `.cat-X.X.X.gem` due to wrong
use of Dir.glob.  This leads to forever re-fetch the gem.
This change fixes the problem by using File::FNM_DOTMATCH.