### PR TITLE
Use Bundler tasks for the new release

### DIFF
--- a/.autotest
+++ b/.autotest
@@ -1,7 +1,0 @@
-# -*- ruby -*-
-
-require 'autotest/restart'
-
-Autotest.add_hook :initialize do |at|
-  at.testlib = 'minitest/unit' if at.respond_to? :testlib=
-end

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg
 doc
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,5 @@
-require 'hoe'
-Hoe.plugin :doofus, :git
-
-Hoe.spec 'rubygems-mirror' do
-  developer('James Tucker', 'jftucker@gmail.com')
-  license "MIT"
-
-  extra_dev_deps << %w[minitest ~>5.7]
-  extra_deps     << %w[net-http-persistent ~>2.9]
-
-  self.extra_rdoc_files = FileList["**/*.rdoc"]
-  self.history_file     = "CHANGELOG.rdoc"
-  self.readme_file      = "README.rdoc"
-  self.testlib          = :minitest
-end
+require "bundler"
+Bundler::GemHelper.install_tasks
 
 namespace :mirror do
   desc "Run the Gem::Mirror::Command"

--- a/lib/rubygems/mirror.rb
+++ b/lib/rubygems/mirror.rb
@@ -1,11 +1,10 @@
 require 'rubygems'
 require 'fileutils'
+require 'rubygems/mirror/version'
 
 class Gem::Mirror
   autoload :Fetcher, 'rubygems/mirror/fetcher'
   autoload :Pool, 'rubygems/mirror/pool'
-
-  VERSION = '1.2.0'
 
   SPECS_FILES = [ "specs.#{Gem.marshal_version}", "prerelease_specs.#{Gem.marshal_version}", "latest_specs.#{Gem.marshal_version}" ]
 

--- a/lib/rubygems/mirror/version.rb
+++ b/lib/rubygems/mirror/version.rb
@@ -1,0 +1,5 @@
+module Gem
+  class Mirror
+    VERSION = '1.2.0'
+  end
+end

--- a/rubygems-mirror.gemspec
+++ b/rubygems-mirror.gemspec
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
+require_relative "lib/rubygems/mirror/version"
 
 Gem::Specification.new do |s|
   s.name = "rubygems-mirror".freeze
-  s.version = "1.2.0"
+  s.version = Gem::Mirror::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]

--- a/rubygems-mirror.gemspec
+++ b/rubygems-mirror.gemspec
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = "rubygems-mirror".freeze
+  s.version = "1.2.0"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["James Tucker".freeze]
+  s.description = "This is an update to the old `gem mirror` command. It uses net/http/persistent\nand threads to grab the mirror set a little faster than the original.\nEventually it will replace `gem mirror` completely. Right now the API is not\ncompletely stable (it will change several times before release), however, I\nwill maintain stability in master.".freeze
+  s.email = ["jftucker@gmail.com".freeze]
+  s.extra_rdoc_files = ["CHANGELOG.rdoc".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "CHANGELOG.rdoc".freeze, "README.rdoc".freeze, "pkg/rubygems-mirror-1.2.0/CHANGELOG.rdoc".freeze, "pkg/rubygems-mirror-1.2.0/README.rdoc".freeze]
+  s.files = File.read('Manifest.txt').split
+  s.homepage = "https://github.com/rubygems/rubygems-mirror".freeze
+  s.licenses = ["MIT".freeze]
+  s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
+  s.rubygems_version = "2.7.6".freeze
+  s.summary = "This is an update to the old `gem mirror` command".freeze
+  s.specification_version = 4
+
+  s.add_runtime_dependency(%q<net-http-persistent>.freeze, ["~> 2.9"])
+  s.add_development_dependency(%q<minitest>.freeze, ["~> 5.7"])
+  s.add_development_dependency(%q<rdoc>.freeze, ["< 7", ">= 4.0"])
+  s.add_development_dependency(%q<hoe>.freeze, ["~> 3.17"])
+end


### PR DESCRIPTION
I'm not familiar with `hoe`. Bundler tasks are majority of Ruby ecosystem.