### PR TITLE
Rakefile: drop "-r ubygems" option in test task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,6 @@ end
 
 namespace :test do
   task :integration do
-    sh Gem.ruby, '-Ilib', '-rubygems', '-S', 'gem', 'mirror'
+    sh Gem.ruby, '-Ilib', '-S', 'gem', 'mirror'
   end
 end


### PR DESCRIPTION
See https://blog.engineyard.com/goodbye-ubygems (2018) about its removal.