### PR TITLE
Modernize and fix up master

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,11 @@ namespace :mirror do
     mirror = Gem::Commands::MirrorCommand.new
     mirror.execute
   end
+
+  task :latest do
+    ENV["RUBYGEMS_MIRROR_ONLY_LATEST"] = "TRUE"
+    Rake::Task["mirror:update"].invoke
+  end
 end
 
 Rake::TestTask.new

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 require "bundler"
 Bundler::GemHelper.install_tasks
+require "rake/testtask"
+
+task :default => :test
 
 namespace :mirror do
   desc "Run the Gem::Mirror::Command"
@@ -11,6 +14,8 @@ namespace :mirror do
     mirror.execute
   end
 end
+
+Rake::TestTask.new
 
 namespace :test do
   task :integration do

--- a/lib/rubygems/mirror/test_setup.rb
+++ b/lib/rubygems/mirror/test_setup.rb
@@ -81,7 +81,6 @@ class Gem::Mirror
           s.author = 'rubygems'
           s.email = 'example@example.com'
           s.homepage = 'http://example.com'
-          s.has_rdoc = false
           s.description = 'desc'
           s.summary = "summ"
           s.require_paths = %w[lib]
@@ -101,7 +100,6 @@ class Gem::Mirror
           s.author = 'rubygems'
           s.email = 'example@example.com'
           s.homepage = 'http://example.com'
-          s.has_rdoc = false
           s.description = 'desc'
           s.summary = "summ"
           s.require_paths = %w[lib]

--- a/rubygems-mirror.gemspec
+++ b/rubygems-mirror.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<net-http-persistent>.freeze, ["~> 2.9"])
   s.add_development_dependency(%q<minitest>.freeze, ["~> 5.7"])
   s.add_development_dependency(%q<rdoc>.freeze, ["< 7", ">= 4.0"])
-  s.add_development_dependency(%q<hoe>.freeze, ["~> 3.17"])
+  s.add_development_dependency(%q<builder>.freeze, ["~> 3.2"])
 end

--- a/test/test_gem_mirror.rb
+++ b/test/test_gem_mirror.rb
@@ -1,3 +1,6 @@
+gem 'builder'
+require 'builder/xchar'
+
 require "rubygems_plugin"
 require "rubygems/mirror"
 require "rubygems/mirror/test_setup"

--- a/test/test_gem_mirror.rb
+++ b/test/test_gem_mirror.rb
@@ -5,7 +5,7 @@ require "rubygems_plugin"
 require "rubygems/mirror"
 require "rubygems/mirror/test_setup"
 
-require 'minitest/autorun' # damn you autotest.
+require "minitest/autorun"
 
 class TestGemMirror < Minitest::Test
   include Gem::Mirror::TestSetup


### PR DESCRIPTION
This gets rid of deprecation warnings, fixes dependencies, and adds
missing test task.

Also adds a mirror:latest rake task so you don't have to remember to
set an environment variable.