### PR TITLE
Fix Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/rubygems/mirror.rb
+++ b/lib/rubygems/mirror.rb
@@ -45,7 +45,7 @@ class Gem::Mirror
       path = to(sf)
 
       @fetcher.fetch(from(sfz), specz)
-      open(path, 'wb') { |f| f << Gem::Util.gunzip(File.binread(specz)) }
+      File.open(path, 'wb') { |f| f << Gem::Util.gunzip(File.binread(specz)) }
     end
   end
 


### PR DESCRIPTION
fix the problem, replace the call to `open(path, 'wb')` with `File.open(path, 'wb')`. This ensures that the file is opened for writing without invoking the potentially dangerous behavior of `Kernel.open`. No other changes are needed, as the rest of the code is compatible with `File.open`. The change should be made in the `update_specs` method, specifically on line 48 of `lib/rubygems/mirror.rb`. No new imports or method definitions are required.

### References
[Command Injection](https://www.owasp.org/index.php/Command_Injection). [Ruby on Rails Cheat Sheet: Command Injection](https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#command-injection)
[Command Injection in RDoc](https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/)